### PR TITLE
Forced maven-jaxb2-plugin locale to ENG to make maven-replacer-plugin…

### DIFF
--- a/mqtt-spy-common/pom.xml
+++ b/mqtt-spy-common/pom.xml
@@ -202,6 +202,7 @@
 			                <goal>generate</goal>
 			            </goals>
 			            <configuration>
+			            	<locale>en</locale>
 			            	<extension>true</extension>
 			                <schemaDirectory>src/main/resources/</schemaDirectory>
 			                <schemaIncludes>

--- a/mqtt-spy/pom.xml
+++ b/mqtt-spy/pom.xml
@@ -226,6 +226,7 @@
 			                <goal>generate</goal>
 			            </goals>
 			            <configuration>
+			            	<locale>en</locale>
 			                <schemaDirectory>src/main/resources/</schemaDirectory>
 			                <schemaIncludes>
 			                    <include>mqtt-spy-configuration.xsd</include>
@@ -288,6 +289,7 @@
 			                <goal>generate</goal>
 			            </goals>
 			            <configuration>
+			            	<locale>en</locale>
 			                <schemaDirectory>src/main/resources/</schemaDirectory>
 			                <schemaIncludes>
 			                    <include>mqtt-spy-versions.xsd</include>
@@ -318,6 +320,7 @@
 			                <goal>generate</goal>
 			            </goals>
 			            <configuration>
+			            	<locale>en</locale>
 			                <schemaDirectory>src/main/resources/</schemaDirectory>
 			                <schemaIncludes>
 			                    <include>mqtt-spy-stats.xsd</include>

--- a/spy-common/pom.xml
+++ b/spy-common/pom.xml
@@ -119,6 +119,7 @@
 			                <goal>generate</goal>
 			            </goals>
 			            <configuration>
+			            	<locale>en</locale>
 			            	<extension>true</extension>
 			                <schemaDirectory>src/main/resources/</schemaDirectory>
 			                <schemaIncludes>


### PR DESCRIPTION
Hi Kamil,
I encountered an inconvenience building mqtt-spy on my laptop. The locale is not set to English so all the comments in files generated by maven-jaxb2-plugin are different.
1. Git sees every generated file as different because comment lines are different
2. Replacements defined for maven-replacer-plugin do not work anymore

As a solution, I edited the POMs and forced maven-jaxb2-plugin locale to ENG to make maven-replacer-plugin replacements work also on build machines with a default locale other than english.

Thank you!