### PR TITLE
Added JUnit 4.12 as test dependency

### DIFF
--- a/spy-common-ui/pom.xml
+++ b/spy-common-ui/pom.xml
@@ -48,6 +48,13 @@
 			<artifactId>jfxutils</artifactId>
 			<version>0.4-SNAPSHOT</version>
 		</dependency>
+
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.12</version>
+			<scope>test</scope>
+		</dependency>
 		
 	</dependencies>
   


### PR DESCRIPTION
When I tried to build this application on my machine I got this error:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.1:testCompile (default-testCompile) on project spy-common-ui: Compilation failure: Compilation failure:
[ERROR] mqtt-spy/spy-common-ui/src/test/java/pl/baczkowicz/spy/xpath/XPathTest.java:[11,17] package org.junit does not exist
[ERROR] mqtt-spy/spy-common-ui/src/test/java/pl/baczkowicz/spy/xpath/XPathTest.java:[19,10] cannot find symbol
[ERROR] symbol:   class Test
[ERROR] location: class pl.baczkowicz.spy.xpath.XPathTest
[ERROR] -> [Help 1]
```

I added JUnit 4.12 as a dependency in the test scope in the spy-common-ui pom.xml and that fixed it.
